### PR TITLE
 脆弱性あったgemは最新のversion使う

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'bootstrap-will_paginate', '1.0.0'
 gem 'sprockets', '>= 3.7.2'
 gem 'rubyzip', '>= 1.2.2'
 gem 'ffi', '>= 1.9.24'
+gem 'railties', '= 5.2.0'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem 'carrierwave',  '1.2.2'
 gem 'mini_magick',  '>= 4.9.4'
 gem 'will_paginate', '3.1.6'
 gem 'bootstrap-will_paginate', '1.0.0'
+gem 'sprockets', '>= 3.7.2'
+gem 'rubyzip', '>= 1.2.2'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'will_paginate', '3.1.6'
 gem 'bootstrap-will_paginate', '1.0.0'
 gem 'sprockets', '>= 3.7.2'
 gem 'rubyzip', '>= 1.2.2'
+gem 'ffi', '>= 1.9.24'
 
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.5.1'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'
 gem 'mysql2', '>= 0.4.4', '< 0.6.0'
-gem 'bootstrap-sass', '3.3.7'
+gem 'bootstrap-sass', '>= 3.4.1'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     execjs (2.7.0)
     faker (1.7.3)
       i18n (~> 0.5)
-    ffi (1.9.23)
+    ffi (1.11.1)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     fog (1.42.0)
@@ -416,6 +416,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   faker (= 1.7.3)
+  ffi (>= 1.9.24)
   fog (= 1.42)
   jbuilder (~> 2.5)
   jquery-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,15 +48,15 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
-    autoprefixer-rails (8.5.0)
+    autoprefixer-rails (9.6.1)
       execjs
     bcrypt-ruby (3.1.1.rc1)
     bindex (0.5.0)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     bootstrap-will_paginate (1.0.0)
       will_paginate
     builder (3.2.3)
@@ -360,6 +360,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
     selenium-webdriver (3.12.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
@@ -408,7 +411,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt-ruby (= 3.1.1.rc1)
   bootsnap (>= 1.1.0)
-  bootstrap-sass (= 3.3.7)
+  bootstrap-sass (>= 3.4.1)
   bootstrap-will_paginate (= 1.0.0)
   byebug
   capybara (>= 2.15, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.3)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -368,7 +368,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -427,10 +427,12 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.0)
   rails-controller-testing
+  rubyzip (>= 1.2.2)
   sass-rails (~> 5.0)
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
+  sprockets (>= 3.7.2)
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,6 +428,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.0)
   rails-controller-testing
+  railties (= 5.2.0)
   rubyzip (>= 1.2.2)
   sass-rails (~> 5.0)
   selenium-webdriver


### PR DESCRIPTION
https://github.com/rails/rails/tree/master/railties railties って rails に依存してるなら rails install 時（たぶんチュートリアル的に5.2.0をいきなりインストールしたとき）に解決できてるはずなのでは？